### PR TITLE
Document the assertion evidence workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ npx supercov runs latest assertions --evidence /tests --limit 5 --json
 This npm-only query uses the run archive and matching source; it adds no new
 test-time instrumentation. It requires a compatible project TypeScript compiler
 API (5.8.3 and native 7.0.2 are tested). Results are candidates, not proof
-that changes are safe or a verified assertion percentage. Follow
-[`assertion-evidence.md`](docs/assertion-evidence.md) for provenance, optional
-assertion hints, pagination, and limitations.
+that changes are safe or a verified assertion percentage. Start with
+[Understanding assertions](docs/assertions.md), then use the
+[evidence reference](docs/assertion-evidence.md) for provenance, optional hints,
+pagination, and limitations.
 
 ## Give Supercov a job
 
@@ -223,6 +224,7 @@ npx supercov clean             # remove all runs and the build cache
 
 - [Getting started](https://supercov.com/docs/getting-started)
 - [Agent workflow](https://supercov.com/docs/agent-loop)
+- [Understanding assertions](docs/assertions.md)
 - [Troubleshooting](https://supercov.com/docs/troubleshooting)
 - [CLI reference](https://supercov.com/docs/cli)
 - [Supported languages and test suites](https://supercov.com/docs/supported-suites)

--- a/docs/agent-loop.md
+++ b/docs/agent-loop.md
@@ -64,7 +64,8 @@ This post-run query needs the matching source and a compatible
 project TypeScript API. An `evident` candidate is not a proof of safety; keep
 test gaps separate from analysis limits. Follow the returned evidence pointers
 and `pagination.nextOffset`, pinning `--analysis` and the run id while paging.
-See [assertion evidence](assertion-evidence.md) for requirements and examples.
+See [Understanding assertions](assertions.md) for the practical workflow and
+[assertion evidence](assertion-evidence.md) for the detailed requirements.
 
 ## Example
 

--- a/docs/assertion-evidence.md
+++ b/docs/assertion-evidence.md
@@ -1,5 +1,8 @@
 # Assertion evidence (JS/TS)
 
+Start with [Understanding assertions](assertions.md) for the practical workflow.
+This reference describes evidence fields, supported source models and their limits.
+
 Supercov can analyze which source behaviors existing assertions appear to check,
 using an ordinary run archive, its matching source, and the existing statement
 and assertion-phase evidence. This work happens after tests. It adds no new

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -1,0 +1,210 @@
+# Understanding assertions
+
+Coverage tells you which code ran. Assertion evidence helps you investigate
+what the tests checked about that code, and where that relationship is still
+unknown.
+
+Use it after a coverage run to choose a useful assertion to add or to review
+the tests around a proposed change. It is not a percentage of code that is safe
+to change.
+
+## Start with the suite you already have
+
+```sh supercov
+npx supercov -- npm test
+npx supercov runs latest assertions --limit 5
+npx supercov runs latest assertions --file src/core.mjs --limit 5 --json
+```
+
+Use your project's complete test command and actual source path. Supercov
+analyzes the stored run and its matching source after the tests finish. The
+query does not execute mutants or rerun application code. It uses the existing
+statement and assertion-phase instrumentation; querying adds no test-time probes.
+
+This source-to-assertion analysis is available for JavaScript and TypeScript
+through the npm launcher, with Node's test runner and Vitest exercised. It is
+separate from structural coverage and assertion-phase linkage in other runners
+and languages.
+
+The project must provide a compatible TypeScript compiler API, even when its
+source is JavaScript. TypeScript 5.8.3 and native 7.0.2 are tested; native 7.0.2
+requires Node 22.12 or newer and its platform-specific compiler package. If you
+add a compiler dependency, rerun the suite before querying. Do not downgrade an
+application's compiler to make a report work. See the
+[requirements](assertion-evidence.md#requirements) for the complete boundary.
+
+## Executed is not the same as checked
+
+Consider this function in `src/core.mjs`:
+
+```js
+export function exact() {
+  return 4;
+}
+```
+
+Each of these assertions calls it, but they check different things. Here,
+`assert` is imported from `node:assert/strict`:
+
+```js
+assert.equal(exact(), 4);
+assert.ok(exact());
+assert.equal((exact(), 7), 7);
+```
+
+| Assertion | What it checks about the returned value |
+| --- | --- |
+| `assert.equal(exact(), 4)` | The result equals the number `4`. Returning `5` would fail this assertion. |
+| `assert.ok(exact())` | The result is truthy. Returning `5` would still pass. |
+| `assert.equal((exact(), 7), 7)` | Nothing: the comma expression discards the result and compares `7` with `7`. |
+
+Those conclusions concern the returned value. A call can also throw, change
+state, or produce output. Discarding its return does not mean removing the call
+is safe, and checking one return does not test every input or side effect.
+
+Likewise, a log-count assertion checks how many calls occurred, not their
+arguments. A substring assertion checks for that substring, not the entire
+message. Reaching a passing assertion later on the same thread does not, by
+itself, establish either relationship.
+
+## Read a result as an investigation
+
+The report inventories source sites, such as decisions, returns and effects,
+and attaches candidate results and supporting evidence. These are not a count
+of assertion statements or a line-by-line safety certificate.
+
+| Candidate | How to use it |
+| --- | --- |
+| `evident` | The analyzer found supporting observations under its rules. Inspect the predicate and source path before relying on them. |
+| `presence` | Evidence supports presence or truthiness, not the value distinctions you might care about. |
+| `partial` | Some relevant evidence is present, but the site's modeled obligations are not all satisfied. Read the remaining reason. |
+| `unresolved` | A test gap or analysis limit remains. The reason tells you which. |
+
+Reasons beginning with `gap:` describe missing execution or checks under the
+analyzer's model. Reasons beginning with `limit:` mean it could not establish
+the relationship. A limit is not proof that the test checks nothing; a candidate
+gap still deserves source review before you write a test.
+
+Open a site and follow its evidence:
+
+```sh supercov-example
+npx supercov runs '<run-id>' assertions --site '<site-id>' --json
+npx supercov runs '<run-id>' assertions --evidence '<returned-pointer>' \
+  --analysis '<analysisId>' --json
+```
+
+Look for the exact passing assertion, its owning test attempt, the value or
+effect it observes, and any transformation between that observation and the
+source site. A test passing overall is not a substitute for that assertion's
+own passing witness.
+
+Use the run id and `analysisId` returned by the first query while paging.
+Follow `pagination.nextOffset` and returned evidence pointers; a short page or
+`detailOnly: true` does not mean evidence was dropped. The
+[evidence reference](assertion-evidence.md#pagination-and-oversized-records)
+explains how to inspect large records.
+
+## Choose a test, a hint, or a limit
+
+After reading the code and evidence, choose the next step:
+
+1. **The behavior never ran.** Add a realistic scenario that reaches it and
+   checks its result. An assertion hint cannot create an MC/DC execution pair.
+2. **The behavior ran, but its relevant result was not checked.** Add or
+   strengthen a real assertion. Prefer a public outcome over internal details.
+3. **An existing assertion checks it, but the analyzer cannot follow the path.**
+   Try a supported inline hint. Keep the assertion itself unchanged.
+4. **The relationship is still unsupported.** Keep the analysis limit visible.
+   Do not rewrite a good test solely to earn a stronger classification.
+
+Subprocesses are a useful example of the fourth case. A helper can collect
+output from the wrong child, select only a history window, transform a buffer,
+or finish before a pipe is fully captured. Recognizing a method called `ready`
+or a passing substring check does not establish which production behavior it
+observed. Some of these relationships remain unresolved even with a hint.
+
+## Point to an existing assertion
+
+An optional `observes` comment names the behavior you believe the next assertion
+checks:
+
+```js
+// observes: src/core.mjs#exact return 4
+assert.equal(exact(), 4);
+```
+
+Use a project-relative source path, the exact function or owner name after `#`,
+and, when needed, a literal source substring to select one inventory site. Put
+the comment immediately before a statement containing one recognized assertion.
+No separate contract file is needed.
+
+After editing the test, rerun and inspect the hints:
+
+```sh supercov
+npx supercov -- npm test
+npx supercov runs latest assertions --pragmas --json
+```
+
+The hint's origin remains `user-suggested`. Its separate validation result is
+`analyzer-supported`, `unresolved`, or `invalid`. Support requires target
+validation, the selected assertion's own passing witness, and a connection the
+analyzer supports. Naming a function cannot make a discarded result observed.
+
+Hints are comments: invalid or unsupported guidance affects the analysis, not
+whether the test passes. They cannot supply a missing assertion, borrow another
+assertion's witness, remove sites from the denominator, or override a limit by
+declaration. Supported hints retain the analysis model's assumptions.
+
+## Ask a specific change question
+
+Some hints also select a bounded source check using a suffix such as
+`; check missing call`, `; check count`, `; check value`, or `; check completion`.
+Each recipe supports particular source shapes and precisely defined changes;
+the suffix is not a general request to prove the named code safe.
+
+For example, `check missing call` can ask whether omitting a supported console
+callback's body would make an existing call-count assertion reject the result.
+It does not ask whether changing the message would be detected.
+
+Read the selected change, model, assumptions and per-variant result together:
+
+- `rejected` means the modeled change would be rejected by the selected
+  assertion within that model.
+- `not-rejected` means that assertion would accept it. Another assertion, later
+  test, or side effect might still cause the suite to fail.
+- An unresolved variant remains unknown even when another variant is checked.
+
+These source models are bounded and trusted, not formally verified interpreters
+for arbitrary JavaScript. Checked hints are reported separately; they do not
+promote ordinary candidates or manufacture coverage. See the
+[hint reference](assertion-evidence.md#optional-assertion-hints) for supported
+shapes, supported changes and each recipe's assumptions.
+
+## What about an assertion percentage?
+
+Supercov does not currently report a verified global assertion percentage.
+`assertionScore` is `null`, not zero. Candidate counts summarize the analysis
+inventory; dividing `evident` sites by all sites does not measure the fraction
+of the library that is safe to change. Candidate `analysisCertainty` remains
+`unverified`, including when separate bounded checks provide useful evidence.
+
+MC/DC measures whether conditions independently affected decisions in the run.
+It does not establish that assertions distinguish the resulting behavior.
+Conversely, a passing value assertion does not supply missing MC/DC cases.
+Use the two views together rather than substituting one percentage for another.
+
+## Keep the evidence current
+
+Assertion queries require source, tests, dependencies and configuration matching
+the run. Editing a pragma changes test source too. Rerun the complete suite after
+changes; do not apply an old conclusion to a new checkout. The query checks
+freshness and records compiler and analyzer identity.
+
+For a proposed code change, the useful result is specific: which existing
+assertions check the behavior you intend to preserve, which distinctions they
+could miss, and what remains unknown. Review those checks, add a meaningful test
+where needed, then run the full suite. An `evident` label is not permission to
+change behavior.
+
+See [Agent workflow](agent-loop.md) for the test-writing loop and
+[Assertion evidence reference](assertion-evidence.md) for the detailed models.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,8 +96,9 @@ npx supercov runs latest assertions --help
 The npm-only `assertions` query runs after tests against matching source. It
 reports unverified candidates, not a proven assertion score or permission to
 change behavior. Its filters differ from the structural queries below; see
+[Understanding assertions](assertions.md) for the workflow and
 [assertion evidence](assertion-evidence.md) for requirements, pagination, and
-optional assertion hints. The guide is also available through
+optional assertion hints. The reference is also bundled with the package:
 `npx supercov docs assertion-evidence`.
 
 ## Narrow a view

--- a/docs/coverage-model.md
+++ b/docs/coverage-model.md
@@ -71,6 +71,10 @@ does not mean the product has no bugs, the assertions are meaningful, or every
 possible input was tested. Review test quality and user-visible behavior, not
 only the percentage.
 
+For JS/TS source-to-assertion analysis, see
+[Understanding assertions](assertions.md). It complements execution coverage;
+it does not turn 100% MC/DC into a guarantee that every behavior is checked.
+
 If source cannot be measured safely, Supercov reports a measurement limit
 instead of claiming completeness.
 

--- a/scripts/asserted-packed-integration.mjs
+++ b/scripts/asserted-packed-integration.mjs
@@ -100,6 +100,7 @@ try {
       `missing shipped analyzer input: ${file}`,
     );
   assert.ok(paths.has("docs/assertion-evidence.md"));
+  assert.ok(paths.has("docs/assertions.md"));
   assert.deepEqual(
     [...paths].filter((path) => path.startsWith("analyzers/typescript/dist/")).sort(),
     ["analyze.js", "archive.js", "awaited-observations.js", "build-identity.json", "compiler.js",


### PR DESCRIPTION
## Summary

- Add a practical Understanding assertions guide, following the existing coverage and agent guides.
- Explain execution versus observation, candidate labels, gaps versus limits, readable inline hints, bounded change questions, and freshness.
- Link the guide from the README, CLI, coverage, agent workflow, and detailed evidence reference.
- Require the new Markdown file in the packed-package integration check.

No runtime, analyzer, command, dependency, version, or release changes. The existing installed reference remains `supercov docs assertion-evidence`.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p supercov` (24 unit and 3 CLI integration tests)
- `npm run test:asserted-package` on TypeScript 5.8.3 and native 7.0.2, using installed tarballs
- `node scripts/package-preflight.mjs`
- Checked local Markdown links and executed all JavaScript examples, including the contrasted return values
- `git diff --check`

This documentation follows the already published v0.0.44 release; it does not retag or republish that release.